### PR TITLE
feat: enable dark mode and update GitHub color palette in Tailwind config

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -17,5 +17,15 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      (function () {
+        try {
+          const stored = localStorage.getItem('theme');
+          const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          const theme = stored || (systemDark ? 'dark' : 'light');
+          if (theme === 'dark') document.documentElement.classList.add('dark');
+        } catch { }
+      })();
+    </script>
   </body>
 </html>

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -9,11 +9,11 @@
   }
   
   .hero-gradient {
-    background: linear-gradient(135deg, #0f1419 0%, #161b22 50%, #21262d 100%);
+    @apply bg-gradient-to-br from-github-bg via-github-surface to-github-bg;
   }
   
   .glass-effect {
-    @apply backdrop-blur-xl bg-white/5 border border-white/10;
+    @apply backdrop-blur-xl bg-github-surface/5 border border-github-border/10;
   }
   
   .grid-cols-13 {

--- a/ui/src/components/ThemeToggle.tsx
+++ b/ui/src/components/ThemeToggle.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+export function ThemeToggle() {
+    const [theme, setTheme] = useState<Theme>(() => {
+        const stored = (localStorage.getItem('theme') as Theme | null);
+        if (stored) return stored;
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    });
+
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === 'dark') root.classList.add('dark');
+        else root.classList.remove('dark');
+        localStorage.setItem('theme', theme);
+    }, [theme]);
+
+    // Optional: react to system theme changes if user hasn't explicitly chosen
+    useEffect(() => {
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        const onChange = (e: MediaQueryListEvent) => {
+            if (!localStorage.getItem('theme')) {
+                setTheme(e.matches ? 'dark' : 'light');
+            }
+        };
+        mq.addEventListener('change', onChange);
+        return () => mq.removeEventListener('change', onChange);
+    }, []);
+
+    return (
+        <button
+            type="button"
+            aria-label="Toggle theme"
+            aria-pressed={theme === 'dark'}
+            title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            onClick={() => setTheme(t => (t === 'dark' ? 'light' : 'dark'))}
+            className="inline-flex text-github-text items-center gap-2 px-3 py-2 text-sm active:border-none focus-within:border-none  focus-within:outline-none transition"
+        >
+            {
+                theme === 'light'
+                    ? <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="lucide lucide-moon-icon lucide-moon"><path d="M20.985 12.486a9 9 0 1 1-9.473-9.472c.405-.022.617.46.402.803a6 6 0 0 0 8.268 8.268c.344-.215.825-.004.803.401" /></svg>
+                    : <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="lucide lucide-sun-icon lucide-sun"><circle cx="12" cy="12" r="4" /><path d="M12 2v2" /><path d="M12 20v2" /><path d="m4.93 4.93 1.41 1.41" /><path d="m17.66 17.66 1.41 1.41" /><path d="M2 12h2" /><path d="M20 12h2" /><path d="m6.34 17.66-1.41 1.41" /><path d="m19.07 4.93-1.41 1.41" /></svg>
+            }
+        </button>
+    );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,3 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    /* Light mode colors */
+    --color-bg: 255 255 255;
+    --color-surface: 248 250 252;
+    --color-border: 226 232 240;
+    --color-text: 17 24 39;
+    --color-muted: 107 114 128;
+  }
+
+  .dark {
+    /* Dark mode colors */
+    --color-bg: 15 20 25;
+    --color-surface: 22 27 34;
+    --color-border: 48 54 61;
+    --color-text: 201 209 217;
+    --color-muted: 139 148 158;
+  }
+}
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/ui/src/pages/LandingPage.tsx
+++ b/ui/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { ThemeToggle } from '../components/ThemeToggle';
 
 const LandingPage = () => {
   const navigate = useNavigate();
@@ -10,12 +11,12 @@ const LandingPage = () => {
   // Check if user is already authenticated and redirect to dashboard
   useEffect(() => {
     console.log('🔍 LandingPage: Starting authentication check...');
-    
+
     try {
       // Check for error states first
       const urlParams = new URLSearchParams(location.search);
       const error = urlParams.get('error');
-      
+
       if (error) {
         console.error('❌ Authentication error:', error);
         return; // Stay on landing page
@@ -25,15 +26,15 @@ const LandingPage = () => {
       const token = localStorage.getItem('github_session_token');
       const accessToken = localStorage.getItem('github_access_token');
       const user = localStorage.getItem('github_user');
-      
-      console.log('🔍 Auth check results:', { 
-        hasToken: !!token, 
-        hasAccessToken: !!accessToken, 
+
+      console.log('🔍 Auth check results:', {
+        hasToken: !!token,
+        hasAccessToken: !!accessToken,
         hasUser: !!user,
         tokenValue: token ? 'present' : 'null',
         userValue: user ? user : 'null'
       });
-      
+
       if ((token || accessToken) && user) {
         // User is already authenticated, redirect to dashboard
         console.log('✅ User already authenticated, redirecting to dashboard');
@@ -47,14 +48,14 @@ const LandingPage = () => {
       // In case of any error, stay on landing page
     }
   }, [navigate, location.search]);
-  
+
   const authGithub = () => {
     setIsAuthenticating(true);
     // Clear any existing auth data before new authentication
     localStorage.removeItem('github_session_token');
     localStorage.removeItem('github_access_token');
     localStorage.removeItem('github_user');
-    
+
     // Redirect to backend OAuth endpoint
     window.location.href = `${backendUrl}/auth/github`;
   };
@@ -68,25 +69,28 @@ const LandingPage = () => {
             <span className="text-2xl animate-pulse-slow drop-shadow-[0_0_8px_#39d353]">🟩</span>
             <span className="text-xl font-bold text-gradient">GreenSquare</span>
           </div>
-          <button 
-            className={`btn-primary text-sm ${isAuthenticating ? 'opacity-75 cursor-not-allowed' : ''}`}
-            onClick={authGithub}
-            disabled={isAuthenticating}
-          >
-            {isAuthenticating ? (
-              <>
-                <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full"></div>
-                Redirecting...
-              </>
-            ) : (
-              <>
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.30.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                </svg>
-                Sign in with GitHub
-              </>
-            )}
-          </button>
+          <div className='flex items-center gap-1'>
+            <button
+              className={`btn-primary text-sm ${isAuthenticating ? 'opacity-75 cursor-not-allowed' : ''}`}
+              onClick={authGithub}
+              disabled={isAuthenticating}
+            >
+              {isAuthenticating ? (
+                <>
+                  <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full"></div>
+                  Redirecting...
+                </>
+              ) : (
+                <>
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.30.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                  </svg>
+                  Sign in with GitHub
+                </>
+              )}
+            </button>
+            <ThemeToggle />
+          </div>
         </div>
       </nav>
 
@@ -108,15 +112,15 @@ const LandingPage = () => {
                 </span>
               </h1>
               <p className="text-base lg:text-lg xl:text-xl text-github-muted leading-relaxed">
-                Turn productivity into a game. Never break your contribution streak again with 
-                <span className="text-github-green-400 font-semibold"> smart reminders</span>, 
-                <span className="text-github-green-400 font-semibold"> streak tracking</span>, and 
+                Turn productivity into a game. Never break your contribution streak again with
+                <span className="text-github-green-400 font-semibold"> smart reminders</span>,
+                <span className="text-github-green-400 font-semibold"> streak tracking</span>, and
                 <span className="text-github-green-400 font-semibold"> gamified coding habits</span>.
               </p>
             </div>
-            
+
             <div className="flex flex-col sm:flex-row gap-4">
-              <button 
+              <button
                 className={`btn-primary text-lg group ${isAuthenticating ? 'opacity-75 cursor-not-allowed' : ''}`}
                 onClick={authGithub}
                 disabled={isAuthenticating}
@@ -129,7 +133,7 @@ const LandingPage = () => {
                 ) : (
                   <>
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" className="group-hover:scale-110 transition-transform">
-                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                     </svg>
                     Get Started Free
                   </>
@@ -154,17 +158,17 @@ const LandingPage = () => {
               <div className="relative group">
                 <div className="absolute inset-0 bg-gradient-to-r from-github-green-400/10 to-github-green-600/10 rounded-xl blur-sm group-hover:blur-none transition-all duration-300"></div>
                 <div className="relative bg-github-surface/40 backdrop-blur-sm border border-github-border/50 rounded-xl p-4 text-center hover:border-github-green-500/50 transition-all duration-300 hover:scale-105">
-                  <div className="text-2xl xl:text-3xl font-bold text-gradient animate-pulse" style={{animationDelay: '0.5s'}}>50K+</div>
+                  <div className="text-2xl xl:text-3xl font-bold text-gradient animate-pulse" style={{ animationDelay: '0.5s' }}>50K+</div>
                   <div className="text-xs xl:text-sm text-github-muted font-medium">Streaks Saved</div>
-                  <div className="absolute top-2 right-2 w-2 h-2 bg-github-green-500 rounded-full animate-pulse" style={{animationDelay: '0.5s'}}></div>
+                  <div className="absolute top-2 right-2 w-2 h-2 bg-github-green-500 rounded-full animate-pulse" style={{ animationDelay: '0.5s' }}></div>
                 </div>
               </div>
               <div className="relative group">
                 <div className="absolute inset-0 bg-gradient-to-r from-github-green-600/10 to-github-green-500/10 rounded-xl blur-sm group-hover:blur-none transition-all duration-300"></div>
                 <div className="relative bg-github-surface/40 backdrop-blur-sm border border-github-border/50 rounded-xl p-4 text-center hover:border-github-green-500/50 transition-all duration-300 hover:scale-105">
-                  <div className="text-2xl xl:text-3xl font-bold text-gradient animate-pulse" style={{animationDelay: '1s'}}>99%</div>
+                  <div className="text-2xl xl:text-3xl font-bold text-gradient animate-pulse" style={{ animationDelay: '1s' }}>99%</div>
                   <div className="text-xs xl:text-sm text-github-muted font-medium">Uptime</div>
-                  <div className="absolute top-2 right-2 w-2 h-2 bg-github-green-600 rounded-full animate-pulse" style={{animationDelay: '1s'}}></div>
+                  <div className="absolute top-2 right-2 w-2 h-2 bg-github-green-600 rounded-full animate-pulse" style={{ animationDelay: '1s' }}></div>
                 </div>
               </div>
             </div>
@@ -177,13 +181,12 @@ const LandingPage = () => {
               <div className="relative bg-github-surface/60 backdrop-blur-sm border border-github-border/50 rounded-2xl p-8">
                 <div className="grid grid-cols-13 gap-2">
                   {Array.from({ length: 91 }, (_, i) => (
-                    <div 
-                      key={i} 
-                      className={`contribution-square ${
-                        i < 65 ? 'filled' : 
-                        i < 78 ? 'partial' : 
-                        i < 85 ? 'light' : 'empty'
-                      }`}
+                    <div
+                      key={i}
+                      className={`contribution-square ${i < 65 ? 'filled' :
+                          i < 78 ? 'partial' :
+                            i < 85 ? 'light' : 'empty'
+                        }`}
                       style={{ animationDelay: `${i * 5}ms` }}
                     ></div>
                   ))}
@@ -226,9 +229,9 @@ const LandingPage = () => {
               <div className="absolute inset-0 bg-gradient-to-r from-github-green-500/20 via-github-green-400/30 to-github-green-500/20 rounded-full blur-xl animate-pulse"></div>
               <div className="relative inline-flex items-center gap-3 bg-gradient-to-r from-github-green-500/10 to-github-green-600/10 border border-github-green-500/30 rounded-full px-6 py-3">
                 <div className="flex gap-1">
-                  <span className="w-2 h-2 bg-github-green-500 rounded-full animate-bounce" style={{animationDelay: '0ms'}}></span>
-                  <span className="w-2 h-2 bg-github-green-400 rounded-full animate-bounce" style={{animationDelay: '150ms'}}></span>
-                  <span className="w-2 h-2 bg-github-green-500 rounded-full animate-bounce" style={{animationDelay: '300ms'}}></span>
+                  <span className="w-2 h-2 bg-github-green-500 rounded-full animate-bounce" style={{ animationDelay: '0ms' }}></span>
+                  <span className="w-2 h-2 bg-github-green-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }}></span>
+                  <span className="w-2 h-2 bg-github-green-500 rounded-full animate-bounce" style={{ animationDelay: '300ms' }}></span>
                 </div>
                 <span className="text-github-green-400 font-semibold tracking-wide">FEATURES</span>
               </div>
@@ -351,7 +354,7 @@ const LandingPage = () => {
             <div className="absolute inset-0 bg-github-green-500/20 rounded-2xl blur-2xl animate-pulse"></div>
             <button className="relative btn-primary text-xl px-12 py-6 group" onClick={authGithub}>
               <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor" className="group-hover:rotate-12 transition-transform">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
               </svg>
               Start Your Streak Journey
             </button>
@@ -373,7 +376,7 @@ const LandingPage = () => {
             ))}
           </div>
         </div>
-        
+
         <div className="relative py-4 px-8 lg:px-16 xl:px-20">
           <div className="max-w-7xl mx-auto">
             {/* Main Footer Content */}
@@ -440,7 +443,7 @@ const LandingPage = () => {
             <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-github-surface/60 via-github-surface/40 to-github-surface/60 backdrop-blur-sm border border-github-border/30 p-8 mb-12">
               <div className="absolute inset-0 bg-gradient-to-r from-github-green-500/5 via-transparent to-github-green-500/5"></div>
               <div className="absolute top-0 left-0 w-full h-1 bg-gradient-to-r from-transparent via-github-green-400 to-transparent"></div>
-              
+
               <div className="relative grid grid-cols-2 lg:grid-cols-4 gap-8 text-center">
                 <div className="group space-y-3">
                   <div className="relative inline-block">
@@ -450,105 +453,105 @@ const LandingPage = () => {
                   <div className="text-sm text-github-muted font-medium group-hover:text-github-green-400 transition-colors">Active Users</div>
                   <div className="w-8 h-0.5 bg-gradient-to-r from-transparent via-github-green-400 to-transparent mx-auto opacity-0 group-hover:opacity-100 transition-opacity"></div>
                 </div>
-                
+
                 <div className="group space-y-3">
                   <div className="relative inline-block">
-                    <div className="absolute inset-0 bg-github-green-500/20 rounded-full blur-xl animate-pulse" style={{animationDelay: '0.5s'}}></div>
+                    <div className="absolute inset-0 bg-github-green-500/20 rounded-full blur-xl animate-pulse" style={{ animationDelay: '0.5s' }}></div>
                     <div className="relative text-3xl xl:text-4xl font-bold text-gradient hover:scale-110 transition-transform duration-300 cursor-default">50,000+</div>
                   </div>
                   <div className="text-sm text-github-muted font-medium group-hover:text-github-green-400 transition-colors">Tracked Commits</div>
                   <div className="w-8 h-0.5 bg-gradient-to-r from-transparent via-github-green-500 to-transparent mx-auto opacity-0 group-hover:opacity-100 transition-opacity"></div>
                 </div>
-                
+
                 <div className="group space-y-3">
                   <div className="relative inline-block">
-                    <div className="absolute inset-0 bg-github-green-600/20 rounded-full blur-xl animate-pulse" style={{animationDelay: '1s'}}></div>
+                    <div className="absolute inset-0 bg-github-green-600/20 rounded-full blur-xl animate-pulse" style={{ animationDelay: '1s' }}></div>
                     <div className="relative text-3xl xl:text-4xl font-bold text-gradient hover:scale-110 transition-transform duration-300 cursor-default">365</div>
                   </div>
                   <div className="text-sm text-github-muted font-medium group-hover:text-github-green-400 transition-colors">Days Supported</div>
                   <div className="w-8 h-0.5 bg-gradient-to-r from-transparent via-github-green-600 to-transparent mx-auto opacity-0 group-hover:opacity-100 transition-opacity"></div>
                 </div>
-                
+
                 <div className="group space-y-3">
                   <div className="relative inline-block">
-                    <div className="absolute inset-0 bg-github-green-400/20 rounded-full blur-xl animate-pulse" style={{animationDelay: '1.5s'}}></div>
+                    <div className="absolute inset-0 bg-github-green-400/20 rounded-full blur-xl animate-pulse" style={{ animationDelay: '1.5s' }}></div>
                     <div className="relative text-3xl xl:text-4xl font-bold text-gradient hover:scale-110 transition-transform duration-300 cursor-default">100%</div>
                   </div>
                   <div className="text-sm text-github-muted font-medium group-hover:text-github-green-400 transition-colors">Open Source</div>
                   <div className="w-8 h-0.5 bg-gradient-to-r from-transparent via-github-green-400 to-transparent mx-auto opacity-0 group-hover:opacity-100 transition-opacity"></div>
                 </div>
               </div>
-              
+
               {/* Floating particles and shooting stars animation */}
               <div className="absolute inset-0 overflow-hidden pointer-events-none">
                 {/* GitHub Green themed shooting stars with random positions */}
-                <div className="absolute -top-4" style={{left: '12%', animation: 'shootingStar1 4s infinite linear'}}>
+                <div className="absolute -top-4" style={{ left: '12%', animation: 'shootingStar1 4s infinite linear' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-16 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/30 to-github-green-400/90 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-12 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/50 to-github-green-400/95 transform rotate-45"></div>
                   </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '67%', animation: 'shootingStar2 5s infinite linear'}}>
+
+                <div className="absolute -top-4" style={{ left: '67%', animation: 'shootingStar2 5s infinite linear' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-20 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/25 to-github-green-500/85 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-14 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/45 to-github-green-500/90 transform rotate-45"></div>
-            </div>
+                  </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '28%', animation: 'shootingStar3 4.5s infinite linear'}}>
+
+                <div className="absolute -top-4" style={{ left: '28%', animation: 'shootingStar3 4.5s infinite linear' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-18 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/30 to-github-green-600/80 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-13 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/40 to-github-green-600/85 transform rotate-45"></div>
-              </div>
+                  </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '84%', animation: 'shootingStar4 3.8s infinite linear'}}>
+
+                <div className="absolute -top-4" style={{ left: '84%', animation: 'shootingStar4 3.8s infinite linear' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-22 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/35 to-github-green-400/90 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-16 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/50 to-github-green-400/95 transform rotate-45"></div>
                     {/* Shooting star head */}
-              </div>
+                  </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '45%', animation: 'shootingStar5 4.2s infinite linear'}}>
+
+                <div className="absolute -top-4" style={{ left: '45%', animation: 'shootingStar5 4.2s infinite linear' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-19 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/28 to-github-green-500/82 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-14 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/42 to-github-green-500/87 transform rotate-45"></div>
                   </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '7%', animation: 'shootingStar1 6s infinite linear', animationDelay: '2s'}}>
+
+                <div className="absolute -top-4" style={{ left: '7%', animation: 'shootingStar1 6s infinite linear', animationDelay: '2s' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-14 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/25 to-github-green-600/80 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-10 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/40 to-github-green-600/85 transform rotate-45"></div>
                   </div>
                 </div>
-                
-                <div className="absolute -top-4" style={{left: '92%', animation: 'shootingStar3 5.5s infinite linear', animationDelay: '3s'}}>
+
+                <div className="absolute -top-4" style={{ left: '92%', animation: 'shootingStar3 5.5s infinite linear', animationDelay: '3s' }}>
                   <div className="relative">
                     {/* Shooting star tail */}
                     <div className="absolute w-17 h-0.5 bg-gradient-to-r from-transparent via-github-green-900/32 to-github-green-500/88 transform rotate-45 blur-[0.5px]"></div>
                     <div className="absolute w-11 h-0.5 bg-gradient-to-r from-transparent via-github-green-800/48 to-github-green-500/92 transform rotate-45"></div>
                   </div>
                 </div>
-                
+
                 {/* Twinkling stars only - removed floating bubbles */}
-                <div className="absolute top-8 left-1/5 w-1 h-1 bg-github-green-400 rounded-full animate-ping opacity-30" style={{animationDelay: '1s'}}></div>
-                <div className="absolute bottom-12 right-1/5 w-0.5 h-0.5 bg-github-green-500 rounded-full animate-ping opacity-40" style={{animationDelay: '2.5s'}}></div>
-                <div className="absolute top-20 right-1/2 w-1 h-1 bg-github-green-600 rounded-full animate-ping opacity-25" style={{animationDelay: '4s'}}></div>
-                <div className="absolute bottom-6 left-1/2 w-0.5 h-0.5 bg-github-green-400 rounded-full animate-ping opacity-35" style={{animationDelay: '0.8s'}}></div>
-                
+                <div className="absolute top-8 left-1/5 w-1 h-1 bg-github-green-400 rounded-full animate-ping opacity-30" style={{ animationDelay: '1s' }}></div>
+                <div className="absolute bottom-12 right-1/5 w-0.5 h-0.5 bg-github-green-500 rounded-full animate-ping opacity-40" style={{ animationDelay: '2.5s' }}></div>
+                <div className="absolute top-20 right-1/2 w-1 h-1 bg-github-green-600 rounded-full animate-ping opacity-25" style={{ animationDelay: '4s' }}></div>
+                <div className="absolute bottom-6 left-1/2 w-0.5 h-0.5 bg-github-green-400 rounded-full animate-ping opacity-35" style={{ animationDelay: '0.8s' }}></div>
+
                 {/* Glowing orbs - simplified and green */}
                 <div className="absolute top-4 right-8 w-2 h-2 bg-github-green-400 rounded-full opacity-10 animate-pulse blur-sm"></div>
-                <div className="absolute bottom-4 left-8 w-3 h-3 bg-github-green-500 rounded-full opacity-8 animate-pulse blur-sm" style={{animationDelay: '1.5s'}}></div>
-                <div className="absolute top-1/2 right-4 w-1.5 h-1.5 bg-github-green-600 rounded-full opacity-12 animate-pulse blur-sm" style={{animationDelay: '3s'}}></div>
+                <div className="absolute bottom-4 left-8 w-3 h-3 bg-github-green-500 rounded-full opacity-8 animate-pulse blur-sm" style={{ animationDelay: '1.5s' }}></div>
+                <div className="absolute top-1/2 right-4 w-1.5 h-1.5 bg-github-green-600 rounded-full opacity-12 animate-pulse blur-sm" style={{ animationDelay: '3s' }}></div>
               </div>
             </div>
 
@@ -560,23 +563,23 @@ const LandingPage = () => {
                 <a href="#" className="hover:text-github-green-400 transition-colors">Cookie Policy</a>
                 <a href="#" className="hover:text-github-green-400 transition-colors">Security</a>
               </div>
-              
+
               <div className="flex items-center gap-4">
                 <span className="text-sm text-github-muted">© 2025 GreenSquare</span>
                 <div className="flex items-center gap-3">
                   <a href="#" className="text-github-muted hover:text-github-green-400 transition-colors p-2 rounded-lg hover:bg-github-border/20">
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
                     </svg>
                   </a>
                   <a href="#" className="text-github-muted hover:text-github-green-400 transition-colors p-2 rounded-lg hover:bg-github-border/20">
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
+                      <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z" />
                     </svg>
                   </a>
                   <a href="#" className="text-github-muted hover:text-github-green-400 transition-colors p-2 rounded-lg hover:bg-github-border/20">
                     <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                      <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419-.0189 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1568 2.4189Z"/>
+                      <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419-.0189 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1568 2.4189Z" />
                     </svg>
                   </a>
                 </div>
@@ -586,7 +589,7 @@ const LandingPage = () => {
         </div>
       </footer>
     </div>
-    )
+  )
 }
 
 export default LandingPage

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
@@ -8,27 +9,21 @@ export default {
     extend: {
       colors: {
         github: {
-          bg: '#0d1117',
-          surface: '#161b22',
-          border: '#30363d',
-          text: '#e6edf3',
-          muted: '#8b949e',
+          bg: 'rgb(var(--color-bg) / <alpha-value>)',
+          surface: 'rgb(var(--color-surface) / <alpha-value>)',
+          border: 'rgb(var(--color-border) / <alpha-value>)',
+          text: 'rgb(var(--color-text) / <alpha-value>)',
+          muted: 'rgb(var(--color-muted) / <alpha-value>)',
           green: {
-            50: '#f0fff4',
-            100: '#dcfce7',
-            200: '#bbf7d0',
-            300: '#86efac',
             400: '#4ade80',
-            500: '#39d353',
-            600: '#26a641',
-            700: '#16a34a',
-            800: '#15803d',
+            500: '#22c55e',
+            600: '#16a34a',
             900: '#14532d',
           }
         }
       },
       fontFamily: {
-        'github': ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Noto Sans', 'Helvetica', 'Arial', 'sans-serif'],
+        github: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Noto Sans', 'Helvetica', 'Arial', 'sans-serif']
       },
       animation: {
         'float': 'float 6s ease-in-out infinite',


### PR DESCRIPTION
Close Issue #13 

**Changes**

- Set darkMode to 'class' for better theme management.
- Refactor GitHub color definitions to use CSS variables for dynamic theming.
- Update green color shades for improved consistency.
- Simplify font family declaration for GitHub styling.



https://github.com/user-attachments/assets/d0a0a709-cd7e-4e89-85be-c3cfb0baad22

